### PR TITLE
feat: Route next-auth errors to login page, and render them

### DIFF
--- a/src/components/LoginCard.tsx
+++ b/src/components/LoginCard.tsx
@@ -81,12 +81,19 @@ const LoginButton = (prop: LoginProps) => {
   );
 };
 
-const LoginCard = () => {
+interface LoginCardProps {
+  errorMsg?: string;
+}
+
+const LoginCard: React.FC<LoginCardProps> = (props) => {
   return (
     <div className="absolute top-1/2 left-1/2 min-w-[85%] -translate-x-1/2 -translate-y-1/2 md:left-3/4 md:min-w-[40vw] ">
       <h2 className="mb-4 text-2xl font-bold text-black dark:text-white">
         Log In
       </h2>
+      {props.errorMsg ? (
+        <p className="pb-4 font-semibold text-red-500"> {props.errorMsg}</p>
+      ) : null}
       <div className="flex flex-col gap-1 rounded-xl border border-zinc-600 bg-white p-4 text-white dark:bg-zinc-800">
         <LoginButton
           key={"google"}

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -19,6 +19,11 @@ export const authOptions: NextAuthOptions = {
       return session;
     },
   },
+  pages: {
+    signIn: "/login",
+    signOut: "/login",
+    error: "/login",
+  },
   // Configure one or more authentication providers
   adapter: PrismaAdapter(prisma),
   providers: [

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,12 +1,30 @@
 import type { GetServerSidePropsContext, NextPage } from "next";
 import Head from "next/head";
 import { getServerAuthSession } from "../server/common/get-server-auth-session";
-
+import { useRouter } from "next/router";
 import DHBranding from "../components/DHBranding";
 import LoginCard from "../components/LoginCard";
 import ThemeToggle from "../components/ThemeToggle";
 
+const errorMsgs = [
+  {
+    name: "OAuthAccountNotLinked",
+    msg: "To confirm your identity, sign in with the same account you used originally.",
+  },
+];
+
 const Login: NextPage = () => {
+  const router = useRouter();
+
+  let isError = false;
+  let errorMsg = undefined;
+  if (router.query.error != undefined) {
+    isError = true;
+    errorMsg =
+      errorMsgs.find((e) => e.name === router.query.error)?.msg ||
+      "Error logging in. If this error persists, please contact us at hello@deltahacks.com for help.";
+  }
+
   return (
     <>
       <Head>
@@ -22,7 +40,7 @@ const Login: NextPage = () => {
         <div className="absolute top-4 right-4">
           <ThemeToggle />
         </div>
-        <LoginCard />
+        <LoginCard errorMsg={isError ? errorMsg : undefined} />
       </div>
     </>
   );
@@ -30,7 +48,6 @@ const Login: NextPage = () => {
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const session = await getServerAuthSession(ctx);
-  console.log(session);
   if (session?.user) {
     return { redirect: { destination: "/welcome", permanent: false } };
   }


### PR DESCRIPTION
Uses https://next-auth.js.org/configuration/pages#sign-in-page a custom page for errors and dynamically renders them on the login page.