### PR TITLE
fix: inaccurate review count in grade page

### DIFF
--- a/src/server/router/application.ts
+++ b/src/server/router/application.ts
@@ -126,6 +126,11 @@ export const applicationRouter = router({
       const statusCount = (
         await ctx.prisma.user.groupBy({
           by: ["status"],
+          where: {
+            dH10ApplicationId: {
+              not: null,
+            },
+          },
           _count: {
             status: true,
           },


### PR DESCRIPTION
![image](https://github.com/deltahacks/portal/assets/71908175/90d39bc1-a5e2-4c80-9364-b24faca17d38)
- The in review count included people without an application yet. This pull request should fix this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the status count calculation in the application overview to ensure more accurate tracking and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->