### PR TITLE
fix: getting thrown back to first page when submitting a review

### DIFF
--- a/src/components/Applicant.tsx
+++ b/src/components/Applicant.tsx
@@ -310,7 +310,6 @@ const ReviewForm = ({
     onSettled() {
       utils.application.getStatusCount.invalidate();
       utils.reviewer.getApplication.invalidate();
-      utils.reviewer.getApplications.invalidate();
     },
   });
 


### PR DESCRIPTION
> hi guys, so i've found an issue with the grading portal - when i press submit review on an applicant which is not on the first page (such that the index of the applicant is > 9), it throws me back to the first page

This issue was because submitting an application was invalidating the getApplications procedure. This was not necessary. I just removed that 1 line and it works now.

https://github.com/user-attachments/assets/53cee251-ab61-4cde-a3d6-9fb6d7da63ed