### PR TITLE
fix: review count not updating when submitting a review

### DIFF
--- a/src/components/Applicant.tsx
+++ b/src/components/Applicant.tsx
@@ -321,6 +321,7 @@ const ReviewForm = ({
     onSettled() {
       utils.application.getStatusCount.invalidate();
       utils.reviewer.getApplication.invalidate();
+      utils.reviewer.getApplications.invalidate();
     },
   });
 

--- a/src/components/Applicant.tsx
+++ b/src/components/Applicant.tsx
@@ -307,6 +307,17 @@ const ReviewForm = ({
 
   const utils = trpc.useUtils();
   const submitScore = trpc.reviewer.submitScore.useMutation({
+    onMutate: async () => {
+      // Optimistically update the review count
+      utils.reviewer.getApplications.setData(undefined, (old) => {
+        if (!old) return old;
+        return old.map((app) =>
+          app.DH11ApplicationId === applicationForReview.DH11ApplicationId
+            ? { ...app, reviewCount: app.reviewCount + 1 }
+            : app
+        );
+      });
+    },
     onSettled() {
       utils.application.getStatusCount.invalidate();
       utils.reviewer.getApplication.invalidate();

--- a/src/components/Applicant.tsx
+++ b/src/components/Applicant.tsx
@@ -307,17 +307,6 @@ const ReviewForm = ({
 
   const utils = trpc.useUtils();
   const submitScore = trpc.reviewer.submitScore.useMutation({
-    onMutate: async () => {
-      // Optimistically update the review count
-      utils.reviewer.getApplications.setData(undefined, (old) => {
-        if (!old) return old;
-        return old.map((app) =>
-          app.DH11ApplicationId === applicationForReview.DH11ApplicationId
-            ? { ...app, reviewCount: app.reviewCount + 1 }
-            : app
-        );
-      });
-    },
     onSettled() {
       utils.application.getStatusCount.invalidate();
       utils.reviewer.getApplication.invalidate();

--- a/src/components/ApplicationsTable.tsx
+++ b/src/components/ApplicationsTable.tsx
@@ -252,6 +252,7 @@ export const ApplicationsTable = ({
       columnVisibility,
       rowSelection,
     },
+    autoResetPageIndex: false,
   });
 
   return (

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -1,4 +1,10 @@
-import Select, { MultiValue, SingleValue, ActionMeta } from "react-select";
+import Select, {
+  MultiValue,
+  SingleValue,
+  ActionMeta,
+  ControlProps,
+  GroupBase,
+} from "react-select";
 
 interface SelectChoice {
   value: string;
@@ -29,7 +35,9 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
       isMulti={isMulti}
       // placeholder="Please select one"
       classNames={{
-        control: (state) => {
+        control: (
+          state: ControlProps<SelectChoice, boolean, GroupBase<SelectChoice>>
+        ) => {
           return state.menuIsOpen
             ? "rounded-md p-3 dark:bg-neutral-800 border-neutral-300 dark:border-neutral-700 bg-white border"
             : "rounded-md p-3 dark:bg-neutral-800 border-neutral-300 dark:border-neutral-700 bg-white border";


### PR DESCRIPTION
TL;DR there's a autoResetPageIndex property for tanstack tables, I set it to false.

I just made PR #218 to fix the pagination issue, but now that getApplications isn't invalidated, the review count in the table doesn't update when a review is submitted.

I tried fixed this by optimistically updating the review count, but this made it go back to the first page like before since the data changing causes a rerender.

So the solution in the end was to invalidate getApplications as before, but set autoResetPageIndex to false on the table.

https://github.com/user-attachments/assets/35d1d49e-752d-4e0b-a2a4-2e998b8bc401