### PR TITLE
fix: status aggregate values in admin grade page

### DIFF
--- a/src/server/router/application.ts
+++ b/src/server/router/application.ts
@@ -124,15 +124,9 @@ export const applicationRouter = router({
       ) {
         throw new TRPCError({ code: "UNAUTHORIZED" });
       }
-      // TODO: Use Status from DH11 Application instaed of User
       const statusCount = (
-        await ctx.prisma.user.groupBy({
+        await ctx.prisma.dH11Application.groupBy({
           by: ["status"],
-          where: {
-            DH11ApplicationId: {
-              not: null,
-            },
-          },
           _count: {
             status: true,
           },


### PR DESCRIPTION
Update the `getStatusCount` function in `src/server/router/application.ts` to use the `DH11Application` model's `status` field instead of the `User` model's `status` field.

* Modify the `getStatusCount` function to use `ctx.prisma.dH11Application.groupBy` instead of `ctx.prisma.user.groupBy`
* Remove the unnecessary `where` clause in the `getStatusCount` function

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/deltahacks/portal/pull/229?shareId=ac96b3ba-61c0-4b2a-b8df-2a0d008bd361).