### PR TITLE
feat: update dashboard for RSVP and add button for consent

### DIFF
--- a/prisma/migrations/20241214025236_feat_add_resume_consent/migration.sql
+++ b/prisma/migrations/20241214025236_feat_add_resume_consent/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DH11Application" ADD COLUMN     "rsvpCheck" BOOL NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,6 +217,8 @@ model DH11Application {
   agreeToMLHPrivacyPolicy  Boolean
   agreeToMLHCommunications Boolean
 
+  rsvpCheck Boolean @default(false)
+
   User User?
 
   DH11Review DH11Review[]

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -65,8 +65,9 @@ const Accepted: React.FC = () => {
   return (
     <div>
       <h1 className="text-2xl font-semibold leading-tight text-black dark:text-white sm:text-3xl lg:text-5xl 2xl:text-6xl">
-        Hey {session ? session.user?.name : ""}, we can{"'"}t wait to see you at
-        DeltaHacks XI!
+        Hey{" "}
+        <span className="capitalize">{session ? session.user?.name : ""}</span>,
+        we can{"'"}t wait to see you at DeltaHacks XI!
       </h1>
       <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         We are pleased to announce that you have been invited to attend
@@ -85,18 +86,26 @@ const Accepted: React.FC = () => {
           hello@deltahacks.com
         </a>
       </div>
-      <div className="t-6 flex flex-col md:flex-row flex-wrap gap-6 pb-24 pt-6">
+      <div className="flex items-center gap-4 pt-4">
         <Checkbox
           id="shareResume"
           checked={shareResume}
-          onCheckedChange={(checked) => setShareResume(checked)}
-          className="text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:text-3xl lg:leading-tight 2xl:text-4xl"
+          onCheckedChange={(checked) => setShareResume(!!checked)}
+          className="w-6 h-6"
+        />
+        <label
+          htmlFor="shareResume"
+          className="text-xl font-normal dark:text-white sm:text-2xl lg:text-3xl lg:leading-tight 2xl:text-4xl"
         >
           Share my resume with sponsors
-        </Checkbox>
+        </label>
+      </div>
+      <div className="t-6 flex flex-col md:flex-row flex-wrap gap-6 pb-24 pt-6">
         <Button
           onClick={async () => {
-            await doRsvp.mutateAsync();
+            await doRsvp.mutateAsync({
+              rsvpCheck: shareResume,
+            });
           }}
           className="btn btn-primary bg-primary dark:bg-primary hover:hover:bg-[#7380ff] dark:hover:bg-[#646EE5] dark:text-white w-48 border-none  text-base font-medium capitalize"
         >
@@ -141,8 +150,11 @@ const Rejected: React.FC = () => {
   return (
     <div>
       <h1 className="text-2xl font-semibold leading-tight text-black dark:text-white sm:text-3xl lg:text-5xl 2xl:text-6xl">
-        Hey {session ? `${session.user?.name}` : ""}, thank you for submitting
-        your application to DeltaHacks XI.
+        Hey{" "}
+        <span className="capitalize">
+          {session ? `${session.user?.name}` : ""}
+        </span>
+        , thank you for submitting your application to DeltaHacks XI.
       </h1>
       <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         We had a lot of amazing applicants this year and were happy to see so
@@ -173,8 +185,11 @@ const Waitlisted: React.FC = () => {
   return (
     <div>
       <h1 className="text-2xl font-semibold leading-tight text-black dark:text-white sm:text-3xl lg:text-5xl 2xl:text-6xl">
-        Hey {session ? `${session.user?.name}` : ""}, thank you for your
-        application to participate in our hackathon!
+        Hey{" "}
+        <span className="capitalize">
+          {session ? `${session.user?.name}` : ""}
+        </span>
+        , thank you for your application to participate in our hackathon!
       </h1>
       <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         Due to the high volume of submissions we have received, we are unable to
@@ -303,8 +318,11 @@ const RSVPed: React.FC = () => {
   return (
     <div>
       <h1 className="text-2xl font-semibold leading-tight text-black dark:text-white sm:text-3xl lg:text-5xl 2xl:text-6xl">
-        Hey {session ? `${session.user?.name}` : ""}, looking forward to seeing
-        you at the hackathon!
+        Hey{" "}
+        <span className="capitalize">
+          {session ? `${session.user?.name}` : ""}
+        </span>
+        , looking forward to seeing you at the hackathon!
       </h1>
       <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         We are pleased to inform you that your registration for DeltaHacks XI

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -72,8 +72,8 @@ const Accepted: React.FC = () => {
       <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         We are pleased to announce that you have been invited to attend
         DeltaHacks XI! Come hack for change and build something incredible with
-        hundreds of other hackers from January 11 - 12, 2025! To confirm that
-        you will be attending, please RSVP below.
+        hundreds of other hackers on January 11 - 12, 2025! To confirm that you
+        will be attending, please RSVP below.
       </h2>
       {/* <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         Sorry, RSVPs are now closed. Thank you so much for your interest in
@@ -158,9 +158,10 @@ const Rejected: React.FC = () => {
       </h1>
       <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         We had a lot of amazing applicants this year and were happy to see so
-        many talented, enthusiastic individuals. Unfortunately, we can’t accept
-        everyone and are unable to offer you a spot at the hackathon at this
-        time. We really hope you’ll apply again next year!
+        many talented, enthusiastic individuals. Unfortunately we were not able
+        to accommodate all applicants this year and are unable to offer you a
+        spot at the hackathon at this time. We really hope you’ll apply again
+        next year!
       </h2>
       <div className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         If you have any questions, you can <br />

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -15,6 +15,7 @@ import React, { useRef } from "react";
 import { useRouter } from "next/router";
 import { Button } from "../components/Button";
 import Drawer from "../components/Drawer";
+import { Checkbox } from "../components/Checkbox";
 
 interface TimeUntilStartInterface {
   hms: [h: number, m: number, s: number];
@@ -59,6 +60,8 @@ const Accepted: React.FC = () => {
     },
   });
 
+  const [shareResume, setShareResume] = React.useState(false);
+
   return (
     <div>
       <h1 className="text-2xl font-semibold leading-tight text-black dark:text-white sm:text-3xl lg:text-5xl 2xl:text-6xl">
@@ -68,7 +71,7 @@ const Accepted: React.FC = () => {
       <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
         We are pleased to announce that you have been invited to attend
         DeltaHacks XI! Come hack for change and build something incredible with
-        hundreds of other hackers from January 12 - 14, 2023! To confirm that
+        hundreds of other hackers from January 11 - 12, 2025! To confirm that
         you will be attending, please RSVP below.
       </h2>
       {/* <h2 className="pt-6 text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:pt-8 lg:text-3xl lg:leading-tight 2xl:pt-10 2xl:text-4xl">
@@ -83,6 +86,14 @@ const Accepted: React.FC = () => {
         </a>
       </div>
       <div className="t-6 flex flex-col md:flex-row flex-wrap gap-6 pb-24 pt-6">
+        <Checkbox
+          id="shareResume"
+          checked={shareResume}
+          onCheckedChange={(checked) => setShareResume(checked)}
+          className="text-xl font-normal dark:text-[#c1c1c1] sm:text-2xl lg:text-3xl lg:leading-tight 2xl:text-4xl"
+        >
+          Share my resume with sponsors
+        </Checkbox>
         <Button
           onClick={async () => {
             await doRsvp.mutateAsync();
@@ -337,19 +348,19 @@ const RSVPed: React.FC = () => {
           </Link>
         </Button>
 
-        <Button className="btn w-48 border-none hover: hover:bg-zinc-700 text-base font-medium capitalize">
+        {/* <Button className="btn w-48 border-none hover: hover:bg-zinc-700 text-base font-medium capitalize">
           <Link className="w-full md:w-48" href="/schedule">
             Schedule
           </Link>
-        </Button>
-        <Button className="btn w-48 border-none hover: hover:bg-zinc-700 text-base font-medium capitalize">
+        </Button> */}
+        {/* <Button className="btn w-48 border-none hover: hover:bg-zinc-700 text-base font-medium capitalize">
           <Link
             className="w-full md:w-48"
             href="/DeltaHacks_X_2024_Attendees_Package.pdf"
           >
             Attendee Package
           </Link>
-        </Button>
+        </Button> */}
       </div>
     </div>
   );
@@ -452,12 +463,7 @@ const WalkIns: React.FC = () => {
 const Dashboard: NextPage<
   InferGetServerSidePropsType<typeof getServerSideProps>
 > = (props) => {
-  // const { data: status, isSuccess } = trpc.application.status.useQuery();
-  // FIXME: After RSVP is implemented, uncomment this and use the correct stauts
-
-  const status = Status.IN_REVIEW;
-
-  // console.log(isSuccess, status);
+  const { data: status, isSuccess } = trpc.application.status.useQuery();
 
   const { data: session } = useSession();
 
@@ -470,9 +476,7 @@ const Dashboard: NextPage<
     [Status.CHECKED_IN]: <CheckedIn />,
   };
 
-  // FIXME: After RSVP is implemented, uncomment this and use the correct stauts
-  // const statusToUse = isSuccess ? status : props.status;
-  const statusToUse = status;
+  const statusToUse = isSuccess ? status : props.status;
 
   return (
     <>

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -61,6 +61,7 @@ const Accepted: React.FC = () => {
   });
 
   const [shareResume, setShareResume] = React.useState(false);
+  const rsvpDialogRef = useRef<HTMLDialogElement | null>(null);
 
   return (
     <div>
@@ -86,28 +87,13 @@ const Accepted: React.FC = () => {
           hello@deltahacks.com
         </a>
       </div>
-      <div className="flex items-center gap-4 pt-4">
-        <Checkbox
-          id="shareResume"
-          checked={shareResume}
-          onCheckedChange={(checked) => setShareResume(!!checked)}
-          className="w-6 h-6"
-        />
-        <label
-          htmlFor="shareResume"
-          className="text-xl font-normal dark:text-white sm:text-2xl lg:text-3xl lg:leading-tight 2xl:text-4xl"
-        >
-          Share my resume with sponsors
-        </label>
-      </div>
       <div className="t-6 flex flex-col md:flex-row flex-wrap gap-6 pb-24 pt-6">
+        {/* When the user clicks this button, open the modal to ask about sharing resume */}
         <Button
-          onClick={async () => {
-            await doRsvp.mutateAsync({
-              rsvpCheck: shareResume,
-            });
+          onClick={() => {
+            rsvpDialogRef.current?.showModal();
           }}
-          className="btn btn-primary bg-primary dark:bg-primary hover:hover:bg-[#7380ff] dark:hover:bg-[#646EE5] dark:text-white w-48 border-none  text-base font-medium capitalize"
+          className="btn btn-primary bg-primary dark:bg-primary hover:hover:bg-[#7380ff] dark:hover:bg-[#646EE5] dark:text-white w-48 border-none text-base font-medium capitalize"
         >
           RSVP
         </Button>
@@ -116,13 +102,64 @@ const Accepted: React.FC = () => {
             FAQ
           </Link>
         </Button>
+      </div>
 
-        {/* <Button>
+      {/* RSVP Modal to confirm sharing resume */}
+      <dialog
+        className="modal modal-bottom sm:modal-middle"
+        ref={rsvpDialogRef}
+      >
+        <div className="modal-box dark:bg-[#1F1F1F]">
+          <h3 className="text-lg font-bold dark:text-white">
+            Complete Your RSVP
+          </h3>
+          <p className="py-4">
+            Would you like to share your resume with our sponsors?
+          </p>
+          <div className="flex items-center gap-4 py-4">
+            <Checkbox
+              id="shareResume"
+              checked={shareResume}
+              onCheckedChange={(checked) => setShareResume(!!checked)}
+              className="w-6 h-6"
+            />
+            <label
+              htmlFor="shareResume"
+              className=" font-normal dark:text-white  lg:leading-tight"
+            >
+              Share my resume with sponsors
+            </label>
+          </div>
+          <div className="modal-action">
+            <form method="dialog">
+              <div className="flex gap-5">
+                <button
+                  className="btn btn-primary dark:bg-primary dark:text-white border-none text-base font-medium capitalize"
+                  onClick={async () => {
+                    await doRsvp.mutateAsync({ rsvpCheck: shareResume });
+                    rsvpDialogRef.current?.close();
+                  }}
+                >
+                  Confirm
+                </button>
+                <button
+                  className="btn bg-zinc-700 dark:text-white border-none text-base font-medium capitalize hover:bg-zinc-800"
+                  onClick={() => rsvpDialogRef.current?.close()}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </dialog>
+
+      {/* <Button>
           <Link className="w-full md:w-48" href="/schedule">
             Schedule
           </Link>
         </Button> */}
-      </div>
+      {/* </div> */}
       {/* <div className="flex flex-col gap-4 pt-6 sm:flex-row md:gap-8">
         <button
           className="btn btn-primary w-48 border-none text-base font-medium capitalize"
@@ -224,6 +261,7 @@ type InReviewProps = {
 const InReview: React.FC<InReviewProps> = ({ killed }) => {
   const { data: session } = useSession();
   const dialogRef = useRef<HTMLDialogElement | null>(null);
+
   const router = useRouter();
   // call deleteApplication endpoint
   const deleteApplication = trpc.application.deleteApplication.useMutation({

--- a/src/server/router/application.ts
+++ b/src/server/router/application.ts
@@ -172,8 +172,7 @@ export const applicationRouter = router({
         throw new TRPCError({ code: "NOT_FOUND" });
       }
 
-      // return user.DH11Application.status; // TODO: Enable this after RSVP consent is implemented
-      return Status.IN_REVIEW;
+      return user.DH11Application.status;
     }),
   qr: protectedProcedure.query(async ({ ctx }) => {
     const user = await ctx.prisma.user.findFirst({
@@ -183,37 +182,42 @@ export const applicationRouter = router({
 
     return qr;
   }),
-  rsvp: protectedProcedure.mutation(async ({ ctx, input }) => {
-    const user = await ctx.prisma?.user.findFirst({
-      where: { id: ctx.session.user.id },
-      include: { DH11Application: true },
-    });
+  rsvp: protectedProcedure
+    .input(
+      z.object({
+        rsvpCheck: z.boolean(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const user = await ctx.prisma?.user.findFirst({
+        where: { id: ctx.session.user.id },
+        include: { DH11Application: true },
+      });
 
-    if (user?.status != Status.ACCEPTED) {
-      throw new Error("Unauthorized call");
-    }
+      if (user?.DH11Application?.status != Status.ACCEPTED) {
+        throw new Error("Unauthorized call");
+      }
 
-    await ctx.prisma?.dH11Application.update({
-      where: { id: user.DH11Application?.id },
-      data: { status: Status.RSVP, rsvpCheck: input.rsvpCheck },
-    });
+      await ctx.prisma?.dH11Application.update({
+        where: { id: user.DH11Application?.id },
+        data: { status: Status.RSVP, rsvpCheck: input.rsvpCheck },
+      });
 
-
-    await ctx.logsnag.track({
-      channel: "rsvps",
-      event: "RSVP Submitted",
-      user_id: `${user.name} - ${user.email}`,
-      description: `${user.name} has submitted their RSVP.`,
-      icon: "🎉",
-    });
-    // await ctx.posthog.capture("RSVP Submitted", {
-    //   user_id: `${user.name} - ${user.email}`,
-    //   description: `${user.name} has submitted their RSVP.`,
-    //   $set: {
-    //     "RSVP Submitted": true,
-    //   },
-    // });
-  }),
+      await ctx.logsnag.track({
+        channel: "rsvps",
+        event: "RSVP Submitted",
+        user_id: `${user.name} - ${user.email}`,
+        description: `${user.name} has submitted their RSVP.`,
+        icon: "🎉",
+      });
+      // await ctx.posthog.capture("RSVP Submitted", {
+      //   user_id: `${user.name} - ${user.email}`,
+      //   description: `${user.name} has submitted their RSVP.`,
+      //   $set: {
+      //     "RSVP Submitted": true,
+      //   },
+      // });
+    }),
   submit: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {

--- a/src/server/router/application.ts
+++ b/src/server/router/application.ts
@@ -183,19 +183,22 @@ export const applicationRouter = router({
 
     return qr;
   }),
-  rsvp: protectedProcedure.mutation(async ({ ctx }) => {
+  rsvp: protectedProcedure.mutation(async ({ ctx, input }) => {
     const user = await ctx.prisma?.user.findFirst({
       where: { id: ctx.session.user.id },
+      include: { DH11Application: true },
     });
 
     if (user?.status != Status.ACCEPTED) {
       throw new Error("Unauthorized call");
     }
 
-    await ctx.prisma?.user.update({
-      where: { id: ctx.session.user.id },
-      data: { status: Status.RSVP },
+    await ctx.prisma?.dH11Application.update({
+      where: { id: user.DH11Application?.id },
+      data: { status: Status.RSVP, rsvpCheck: input.rsvpCheck },
     });
+
+
     await ctx.logsnag.track({
       channel: "rsvps",
       event: "RSVP Submitted",


### PR DESCRIPTION
Extend the Prisma schema and TRPC endpoints to handle RSVP check value.

* **Prisma Schema**:
  - Add a new field `rsvpCheck` of type `Boolean` to the `DH11Application` model in `prisma/schema.prisma`.

* **TRPC Endpoints**:
  - Update the `rsvp` mutation in `src/server/router/application.ts` to store the RSVP check value in the database.
  - Include the RSVP check value in the relevant queries and mutations.

* **Dashboard Page**:
  - Update the text for different statuses in `src/pages/dashboard.tsx` to reflect the new requirements.
  - Comment out the code for the attendee package and schedules.
  - Make the styles consistent.
  - Update the event dates to January 11 - 12, 2025.
  - Add a checkmark toggle to ask if users want to share their resume with sponsors on the ACCEPTED page.

