### PR TITLE
feat: improve judging form design, show table projects list

### DIFF
--- a/src/pages/judging.tsx
+++ b/src/pages/judging.tsx
@@ -105,6 +105,76 @@ const Judging: NextPage = () => {
       label: `Table ${table.number} - ${table.track.name}`,
     })) || [];
 
+  const QuestionSection = ({
+    title,
+    questions,
+    control,
+    borderColor,
+  }: {
+    title: string;
+    questions: typeof rubricQuestions;
+    control: any;
+    borderColor: string;
+  }) => (
+    <div className="mb-8">
+      <h3
+        className={`text-lg font-bold mb-4 p-3 border-l-4 border-${borderColor} bg-base-200 rounded-r`}
+      >
+        {title}
+      </h3>
+      {questions?.map((question, index) => (
+        <div key={question.id}>
+          {index > 0 && <hr className="my-6 border-neutral-700" />}
+          <div className="form-control mb-4">
+            <label className="label">
+              <span className="label-text">
+                <div className="mb-1">
+                  <span className="font-bold">{question.title}</span>
+                  <span> • {question.points} points</span>
+                </div>
+                <ReactMarkdown className="prose">
+                  {question.question}
+                </ReactMarkdown>
+              </span>
+            </label>
+            <div className="rating rating-lg">
+              <Controller
+                name={`scores.${question.id}`}
+                control={control}
+                defaultValue={0}
+                rules={{ required: true }}
+                render={({ field: { onChange, value } }) => (
+                  <div className="flex flex-col">
+                    <div className="flex gap-2">
+                      {[0, 1, 2, 3].map((score) => (
+                        <button
+                          key={score}
+                          type="button"
+                          className={`btn aspect-square rounded-xl p-0 ${
+                            value === score ? "btn-primary" : "btn-outline"
+                          }`}
+                          onClick={() => onChange(score)}
+                        >
+                          {score}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="mt-2 text-sm text-neutral-500">
+                      {value === 0 && "0 - Ineffective / Bad"}
+                      {value === 1 && "1 - Limited / Okay"}
+                      {value === 2 && "2 - Functional / Good"}
+                      {value === 3 && "3 - Exceptional / Phenomenal"}
+                    </div>
+                  </div>
+                )}
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
   return (
     <>
       <Head>
@@ -172,168 +242,49 @@ const Judging: NextPage = () => {
 
                     {allQuestions && allQuestions.length > 0 ? (
                       <form onSubmit={handleSubmit(onSubmit)} className="mt-4">
-                        {/* Track-specific questions section */}
+                        {/* Track-specific questions */}
                         {rubricQuestions &&
                           rubricQuestions.length > 0 &&
                           tables
                             ?.find((t) => t.id === selectedTable?.value)
                             ?.track.name.toLowerCase() !== "general" && (
-                            <div className="mb-8">
-                              <h3 className="text-lg font-bold mb-4 p-3 border-l-4 border-primary bg-base-200 rounded-r">
-                                {
-                                  tables?.find(
-                                    (t) => t.id === selectedTable?.value
-                                  )?.track.name
-                                }{" "}
-                                Track Questions
-                              </h3>
-                              {rubricQuestions.map((question, index) => (
-                                <div key={question.id}>
-                                  {index > 0 && (
-                                    <hr className="my-6 border-neutral-700" />
-                                  )}
-                                  <div className="form-control mb-4">
-                                    <label className="label">
-                                      <span className="label-text">
-                                        <div className="mb-1">
-                                          <span className="font-bold">
-                                            {question.title}
-                                          </span>
-                                          <span>
-                                            {" "}
-                                            • {question.points} points
-                                          </span>
-                                        </div>
-                                        <ReactMarkdown className="prose">
-                                          {question.question}
-                                        </ReactMarkdown>
-                                      </span>
-                                    </label>
-                                    <div className="rating rating-lg">
-                                      <Controller
-                                        name={`scores.${question.id}`}
-                                        control={control}
-                                        defaultValue={0}
-                                        rules={{ required: true }}
-                                        render={({
-                                          field: { onChange, value },
-                                        }) => (
-                                          <div className="flex flex-col">
-                                            <div className="flex gap-2">
-                                              {[0, 1, 2, 3].map((score) => (
-                                                <button
-                                                  key={score}
-                                                  type="button"
-                                                  className={`btn ${
-                                                    value === score
-                                                      ? "btn-primary"
-                                                      : "btn-outline"
-                                                  }`}
-                                                  onClick={() =>
-                                                    onChange(score)
-                                                  }
-                                                >
-                                                  {score}
-                                                </button>
-                                              ))}
-                                            </div>
-                                            <div className="mt-2 text-sm text-neutral-500">
-                                              {value === 0 &&
-                                                "0 - Ineffective / Bad"}
-                                              {value === 1 &&
-                                                "1 - Limited / Okay"}
-                                              {value === 2 &&
-                                                "2 - Functional / Good"}
-                                              {value === 3 &&
-                                                "3 - Exceptional / Phenomenal"}
-                                            </div>
-                                          </div>
-                                        )}
-                                      />
-                                    </div>
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
+                            <QuestionSection
+                              title={`${
+                                tables?.find(
+                                  (t) => t.id === selectedTable?.value
+                                )?.track.name
+                              } Track Questions`}
+                              questions={rubricQuestions}
+                              control={control}
+                              borderColor="primary"
+                            />
                           )}
 
-                        {/* General questions section */}
-                        <div className="mb-8">
-                          <h3 className="text-lg font-bold mb-4 p-3 border-l-4 border-secondary bg-base-200 rounded-r">
-                            {tables
-                              ?.find((t) => t.id === selectedTable?.value)
-                              ?.track.name.toLowerCase() === "general"
-                              ? "General Track Questions"
-                              : "General Questions"}
-                          </h3>
-                          {(tables
-                            ?.find((t) => t.id === selectedTable?.value)
-                            ?.track.name.toLowerCase() === "general"
-                            ? rubricQuestions
-                            : generalQuestions
-                          )?.map((question, index) => (
-                            <div key={question.id}>
-                              {index > 0 && (
-                                <hr className="my-6 border-neutral-700" />
-                              )}
-                              <div className="form-control mb-4">
-                                <label className="label">
-                                  <span className="label-text">
-                                    <div className="mb-1">
-                                      <span className="font-bold">
-                                        {question.title}
-                                      </span>
-                                      <span> • {question.points} points</span>
-                                    </div>
-
-                                    <ReactMarkdown className="prose">
-                                      {question.question}
-                                    </ReactMarkdown>
-                                  </span>
-                                </label>
-                                <div className="rating rating-lg">
-                                  <Controller
-                                    name={`scores.${question.id}`}
-                                    control={control}
-                                    defaultValue={0}
-                                    rules={{ required: true }}
-                                    render={({
-                                      field: { onChange, value },
-                                    }) => (
-                                      <div className="flex flex-col">
-                                        <div className="flex gap-2">
-                                          {[0, 1, 2, 3].map((score) => (
-                                            <button
-                                              key={score}
-                                              type="button"
-                                              className={`btn ${
-                                                value === score
-                                                  ? "btn-primary"
-                                                  : "btn-outline"
-                                              }`}
-                                              onClick={() => onChange(score)}
-                                            >
-                                              {score}
-                                            </button>
-                                          ))}
-                                        </div>
-                                        <div className="mt-2 text-sm text-neutral-500">
-                                          {value === 0 &&
-                                            "0 - Ineffective / Bad"}
-                                          {value === 1 && "1 - Limited / Okay"}
-                                          {value === 2 &&
-                                            "2 - Functional / Good"}
-                                          {value === 3 &&
-                                            "3 - Exceptional / Phenomenal"}
-                                        </div>
-                                      </div>
-                                    )}
-                                  />
-                                </div>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
+                        {/* General questions */}
+                        {(tables
+                          ?.find((t) => t.id === selectedTable?.value)
+                          ?.track.name.toLowerCase() === "general"
+                          ? rubricQuestions
+                          : generalQuestions) && (
+                          <QuestionSection
+                            title={
+                              tables
+                                ?.find((t) => t.id === selectedTable?.value)
+                                ?.track.name.toLowerCase() === "general"
+                                ? "General Track Questions"
+                                : "General Questions"
+                            }
+                            questions={
+                              tables
+                                ?.find((t) => t.id === selectedTable?.value)
+                                ?.track.name.toLowerCase() === "general"
+                                ? rubricQuestions
+                                : generalQuestions
+                            }
+                            control={control}
+                            borderColor="secondary"
+                          />
+                        )}
 
                         <button type="submit" className="btn btn-primary mt-4">
                           Submit Judgment

--- a/src/pages/judging.tsx
+++ b/src/pages/judging.tsx
@@ -93,6 +93,7 @@ const Judging: NextPage = () => {
         onSuccess: () => {
           reset();
           refetchNextProject();
+          window.scrollTo({ top: 0, behavior: "smooth" });
         },
       }
     );
@@ -110,12 +111,12 @@ const Judging: NextPage = () => {
         <title>Dashboard - DeltaHacks XI</title>
       </Head>
 
-      <div className="drawer drawer-end relative h-full min-h-screen w-full overflow-x-hidden font-montserrat">
+      <div className="drawer drawer-end relative min-h-screen w-full overflow-x-hidden font-montserrat">
         <input id="my-drawer-3" type="checkbox" className="drawer-toggle" />
 
         <Drawer pageTabs={[{ pageName: "Dashboard", link: "/dashboard" }]}>
-          <main className="-transform-x-1/2  static left-1/2 top-1/2 flex flex-col items-center justify-center px-7 py-16 sm:px-14 md:flex-row md:gap-4 lg:pl-20 2xl:w-8/12 2xl:pt-20 ">
-            <div className="container mx-auto p-4">
+          <main className="static flex flex-col items-center justify-center px-7 py-16 sm:px-14 md:flex-row md:gap-4 lg:pl-20 2xl:w-8/12 2xl:pt-20">
+            <div className="w-full p-4">
               <h1 className="text-2xl font-bold mb-4">Project Judging</h1>
 
               <div className="mb-4">
@@ -194,15 +195,18 @@ const Judging: NextPage = () => {
                                   <div className="form-control mb-4">
                                     <label className="label">
                                       <span className="label-text">
-                                        <div className="font-bold mb-1">
-                                          {question.title}
+                                        <div className="mb-1">
+                                          <span className="font-bold">
+                                            {question.title}
+                                          </span>
+                                          <span>
+                                            {" "}
+                                            • {question.points} points
+                                          </span>
                                         </div>
                                         <ReactMarkdown className="prose">
                                           {question.question}
                                         </ReactMarkdown>
-                                      </span>
-                                      <span className="label-text-alt">
-                                        Points: {question.points}
                                       </span>
                                     </label>
                                     <div className="rating rating-lg">
@@ -214,7 +218,7 @@ const Judging: NextPage = () => {
                                         render={({
                                           field: { onChange, value },
                                         }) => (
-                                          <>
+                                          <div className="flex flex-col">
                                             <div className="flex gap-2">
                                               {[0, 1, 2, 3].map((score) => (
                                                 <button
@@ -243,7 +247,7 @@ const Judging: NextPage = () => {
                                               {value === 3 &&
                                                 "3 - Exceptional / Phenomenal"}
                                             </div>
-                                          </>
+                                          </div>
                                         )}
                                       />
                                     </div>
@@ -275,15 +279,16 @@ const Judging: NextPage = () => {
                               <div className="form-control mb-4">
                                 <label className="label">
                                   <span className="label-text">
-                                    <div className="font-bold mb-1">
-                                      {question.title}
+                                    <div className="mb-1">
+                                      <span className="font-bold">
+                                        {question.title}
+                                      </span>
+                                      <span> • {question.points} points</span>
                                     </div>
+
                                     <ReactMarkdown className="prose">
                                       {question.question}
                                     </ReactMarkdown>
-                                  </span>
-                                  <span className="label-text-alt">
-                                    Points: {question.points}
                                   </span>
                                 </label>
                                 <div className="rating rating-lg">
@@ -295,7 +300,7 @@ const Judging: NextPage = () => {
                                     render={({
                                       field: { onChange, value },
                                     }) => (
-                                      <>
+                                      <div className="flex flex-col">
                                         <div className="flex gap-2">
                                           {[0, 1, 2, 3].map((score) => (
                                             <button
@@ -321,7 +326,7 @@ const Judging: NextPage = () => {
                                           {value === 3 &&
                                             "3 - Exceptional / Phenomenal"}
                                         </div>
-                                      </>
+                                      </div>
                                     )}
                                   />
                                 </div>

--- a/src/pages/judging.tsx
+++ b/src/pages/judging.tsx
@@ -162,69 +162,70 @@ const Judging: NextPage = () => {
     title,
     questions,
     control,
-    borderColor,
   }: {
     title: string;
     questions: typeof rubricQuestions;
     control: any;
-    borderColor: string;
   }) => (
-    <div className="mb-8">
-      <h3
-        className={`text-lg font-bold mb-4 p-3 border-l-4 border-${borderColor} bg-base-200 rounded-r`}
-      >
-        {title}
-      </h3>
-      {questions?.map((question, index) => (
-        <div key={question.id}>
-          {index > 0 && <hr className="my-6 border-neutral-700" />}
-          <div className="form-control mb-4">
-            <label className="label">
-              <span className="label-text">
-                <div className="mb-1">
-                  <span className="font-bold">{question.title}</span>
-                  <span> • {question.points} points</span>
+    <div className="mt-6">
+      <h3 className="text-xl font-bold mb-2">{title}</h3>
+      <div className="space-y-4">
+        {questions?.map((question) => (
+          <div key={question.id} className="card bg-base-200 shadow-sm">
+            <div className="card-body p-4 sm:p-8 gap-4">
+              {/* Question header with points */}
+              <div className="flex items-center justify-between">
+                <h4 className="font-bold">{question.title}</h4>
+                <div className="badge badge-neutral whitespace-nowrap">
+                  {question.points} points
                 </div>
-                <ReactMarkdown className="prose">
-                  {question.question}
-                </ReactMarkdown>
-              </span>
-            </label>
-            <div className="rating rating-lg">
-              <Controller
-                name={`scores.${question.id}`}
-                control={control}
-                defaultValue={0}
-                rules={{ required: true }}
-                render={({ field: { onChange, value } }) => (
-                  <div className="flex flex-col">
-                    <div className="flex gap-2">
-                      {[0, 1, 2, 3].map((score) => (
-                        <button
-                          key={score}
-                          type="button"
-                          className={`btn aspect-square rounded-xl p-0 ${
-                            value === score ? "btn-primary" : "btn-outline"
-                          }`}
-                          onClick={() => onChange(score)}
-                        >
-                          {score}
-                        </button>
-                      ))}
+              </div>
+
+              {/* Main question text */}
+              <div className="prose prose-lg max-w-none">
+                <ReactMarkdown>{question.question}</ReactMarkdown>
+              </div>
+
+              {/* Scoring section */}
+              <div className="pt-2">
+                <div className="text-sm font-semibold text-neutral-500 mb-2">
+                  Score:
+                </div>
+                <Controller
+                  name={`scores.${question.id}`}
+                  control={control}
+                  defaultValue={0}
+                  rules={{ required: true }}
+                  render={({ field: { onChange, value } }) => (
+                    <div className="flex flex-col">
+                      <div className="flex gap-2 sm:gap-3">
+                        {[0, 1, 2, 3].map((score) => (
+                          <button
+                            key={score}
+                            type="button"
+                            className={`btn sm:btn-md aspect-square rounded-xl p-0 ${
+                              value === score ? "btn-primary" : "btn-outline"
+                            }`}
+                            onClick={() => onChange(score)}
+                          >
+                            {score}
+                          </button>
+                        ))}
+                      </div>
+                      <div className="mt-2 text-sm text-neutral-500">
+                        {value === 0 && "0 - Ineffective / Bad"}
+                        {value === 1 && "1 - Limited / Okay"}
+                        {value === 2 && "2 - Functional / Good"}
+                        {value === 3 && "3 - Exceptional / Phenomenal"}
+                      </div>
                     </div>
-                    <div className="mt-2 text-sm text-neutral-500">
-                      {value === 0 && "0 - Ineffective / Bad"}
-                      {value === 1 && "1 - Limited / Okay"}
-                      {value === 2 && "2 - Functional / Good"}
-                      {value === 3 && "3 - Exceptional / Phenomenal"}
-                    </div>
-                  </div>
-                )}
-              />
+                  )}
+                />
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 
@@ -238,7 +239,7 @@ const Judging: NextPage = () => {
         <input id="my-drawer-3" type="checkbox" className="drawer-toggle" />
 
         <Drawer pageTabs={[{ pageName: "Dashboard", link: "/dashboard" }]}>
-          <main className="static flex flex-col items-center justify-center px-7 py-16 sm:px-14 lg:pl-20">
+          <main className="static flex flex-col items-center justify-center px-4 py-8 sm:px-14 lg:pl-20 sm:py-16">
             <div className="w-full lg:flex lg:gap-8">
               <div className="flex-1">
                 <h1 className="text-2xl font-bold mb-4">Project Judging</h1>
@@ -280,32 +281,48 @@ const Judging: NextPage = () => {
                 <div className="flex flex-col lg:flex-row gap-4">
                   {/* Project judging form */}
                   {selectedTable && nextProject && (
-                    <div className="flex-1 rounded-md h-fit p-3 dark:bg-neutral-800 border-neutral-300 dark:border-neutral-700 bg-white border">
+                    <div className="flex-1 rounded-md h-fit p-3 sm:p-6 dark:bg-neutral-800 border-neutral-300 dark:border-neutral-700 bg-white border">
                       <div
-                        className={`p-4 ${
-                          isProjectLoading ? "opacity-50" : ""
-                        }`}
+                        className={`${isProjectLoading ? "opacity-50" : ""}`}
                       >
-                        <h2 className="text-xl font-bold mb-2">
-                          {nextProject.name}
-                        </h2>
-                        <p className="line-clamp-4">
-                          {nextProject.description}
-                        </p>
-                        <a
-                          href={nextProject.link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="link"
-                        >
-                          Project Link
-                        </a>
+                        <div className="card bg-base-200">
+                          <div className="card-body p-4 sm:p-8">
+                            <div>
+                              <div className="text-sm font-semibold text-neutral-500">
+                                Project Name
+                              </div>
+                              <h2 className="card-title text-2xl">
+                                {nextProject.name}
+                              </h2>
+                            </div>
+                            <div>
+                              <div className="text-sm font-semibold text-neutral-500">
+                                Project Link
+                              </div>
+                              <a
+                                href={nextProject.link}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="link break-all"
+                              >
+                                {nextProject.link || "No link available"}
+                              </a>
+                            </div>
+                            <div className="">
+                              <div className="text-sm font-semibold text-neutral-500">
+                                Project Description
+                              </div>
+                              <p className="">
+                                {nextProject.description ||
+                                  "No description available"}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
 
+                        {/* Rest of the form */}
                         {allQuestions && allQuestions.length > 0 ? (
-                          <form
-                            onSubmit={handleSubmit(onSubmit)}
-                            className="mt-4"
-                          >
+                          <form onSubmit={handleSubmit(onSubmit)}>
                             {/* Track-specific questions */}
                             {rubricQuestions &&
                               rubricQuestions.length > 0 &&
@@ -320,7 +337,6 @@ const Judging: NextPage = () => {
                                   } Track Questions`}
                                   questions={rubricQuestions}
                                   control={control}
-                                  borderColor="primary"
                                 />
                               )}
 
@@ -346,13 +362,12 @@ const Judging: NextPage = () => {
                                     : generalQuestions
                                 }
                                 control={control}
-                                borderColor="secondary"
                               />
                             )}
 
                             <button
                               type="submit"
-                              className="btn btn-primary mt-4"
+                              className="btn btn-primary mt-8"
                             >
                               Submit Judgment
                             </button>

--- a/src/pages/judging.tsx
+++ b/src/pages/judging.tsx
@@ -44,6 +44,7 @@ const Judging: NextPage = () => {
     trpc.table.getTables.useQuery();
   const { mutate: submitJudgment } =
     trpc.judging.createJudgingResult.useMutation();
+  // TODO: Change this endpoint to only handle one thing, not filtering on projectId
   const {
     data: nextProject,
     refetch: refetchNextProject,
@@ -280,7 +281,18 @@ const Judging: NextPage = () => {
                 </div>
                 <div className="flex flex-col lg:flex-row gap-4">
                   {/* Project judging form */}
-                  {selectedTable && nextProject && (
+                  {!nextProject && (
+                    /* Placeholder for no projects */
+
+                    <div className="flex-1 rounded-md h-fit p-3 sm:p-6 dark:bg-neutral-800 border-neutral-300 dark:border-neutral-700 bg-white border">
+                      <h1>No projects available</h1>
+                      <p className="text-neutral-500">
+                        There are no more projects available for judging at this
+                        time.
+                      </p>
+                    </div>
+                  )}
+                  {nextProject && selectedTable && (
                     <div className="flex-1 rounded-md h-fit p-3 sm:p-6 dark:bg-neutral-800 border-neutral-300 dark:border-neutral-700 bg-white border">
                       <div
                         className={`${isProjectLoading ? "opacity-50" : ""}`}

--- a/src/server/router/judging.ts
+++ b/src/server/router/judging.ts
@@ -215,6 +215,19 @@ export const projectRouter = router({
         },
       });
 
+      // If all projects have been judged, return the first project
+      if (!timeSlot) {
+        return ctx.prisma.project.findFirst({
+          where: {
+            TimeSlot: {
+              some: {
+                tableId: input.tableId,
+              },
+            },
+          },
+        });
+      }
+
       return timeSlot?.project;
     }),
   getAllProjects: protectedProcedure.query(async ({ ctx }) => {

--- a/src/server/router/judging.ts
+++ b/src/server/router/judging.ts
@@ -215,17 +215,8 @@ export const projectRouter = router({
         },
       });
 
-      // If all projects have been judged, return the first project
       if (!timeSlot) {
-        return ctx.prisma.project.findFirst({
-          where: {
-            TimeSlot: {
-              some: {
-                tableId: input.tableId,
-              },
-            },
-          },
-        });
+        return null;
       }
 
       return timeSlot?.project;


### PR DESCRIPTION
Improved the judging form design, and added a list of projects which the judge can use to navigate to different projects at the table. They can also update their previously submitted scores.

Demo:

https://github.com/user-attachments/assets/975d839f-2b7d-4df6-b2ce-eada43fd6397


<details>
  <summary>Desktop dark:</summary>

  ![image](https://github.com/user-attachments/assets/49f9b9ea-e457-45f0-ad78-aa40dbf9df8d)

</details>

<details>
  <summary>Desktop light:</summary>

  ![image](https://github.com/user-attachments/assets/446655f1-bc66-4a44-8b17-2a1c84831e97)

</details>

<details>
  <summary>Mobile dark:</summary>

  ![image](https://github.com/user-attachments/assets/598244f7-ddfd-49a4-bb21-fc453b29676e)

</details>

<details>
  <summary>Mobile light:</summary>

  ![image](https://github.com/user-attachments/assets/ab72dfc1-efd4-446d-9dc8-b60a5c464f4d)

</details>
