### PR TITLE
fix: use applicationNumber instead of row index for grading portal "#" column

### DIFF
--- a/src/components/ApplicationsTable.tsx
+++ b/src/components/ApplicationsTable.tsx
@@ -31,9 +31,9 @@ import { Status } from "@prisma/client";
 
 const columns: ColumnDef<ApplicationForReview>[] = [
   {
-    accessorKey: "index",
-    accessorFn: (_row, index) => index,
+    accessorKey: "applicationNumber",
     filterFn: (row, columnId, filterValue) => {
+      if (filterValue === "" || filterValue === undefined) return true;
       return row.getValue(columnId) === Number(filterValue);
     },
     header: ({ column }) => {
@@ -48,7 +48,9 @@ const columns: ColumnDef<ApplicationForReview>[] = [
         </Button>
       );
     },
-    cell: ({ row }) => <div className="pl-4 py-2">{row.getValue("index")}</div>,
+    cell: ({ row }) => (
+      <div className="pl-4 py-2">{row.getValue("applicationNumber")}</div>
+    ),
     enableColumnFilter: true,
     enableSorting: true,
   },
@@ -254,7 +256,7 @@ const SearchBarFilter = <TData,>({
         <Filter />
       </div>
       <SelectionDropdown
-        className="w-40 rounded-none rounded-l-lg bg-primary font-bold dark:bg-primary text-white hover:text-white dark:text-white hover:bg-primary/60 hover:dark:bg-primary/80"
+        className="w-52 rounded-none rounded-l-lg bg-primary font-bold dark:bg-primary text-white hover:text-white dark:text-white hover:bg-primary/60 hover:dark:bg-primary/80"
         selections={Array.from(filterableColumnsMap.keys())}
         defaultSelection={capitalize(defaultColumnToFilter.id)}
         onChangedSelection={changeFilteredColumnToSelection}
@@ -319,7 +321,7 @@ export const ApplicationsTable = ({
         <div className="flex items-center justify-between py-4">
           <SearchBarFilter
             columns={table.getAllColumns()}
-            defaultColumnToFilter={table.getColumn("index")}
+            defaultColumnToFilter={table.getColumn("applicationNumber")}
             defaultFilterValue={""}
           />
           <ColumnFilterDropdown columns={table.getAllColumns()} />

--- a/src/components/ApplicationsTable.tsx
+++ b/src/components/ApplicationsTable.tsx
@@ -33,7 +33,6 @@ const columns: ColumnDef<ApplicationForReview>[] = [
   {
     accessorKey: "applicationNumber",
     filterFn: (row, columnId, filterValue) => {
-      if (filterValue === "" || filterValue === undefined) return true;
       return row.getValue(columnId) === Number(filterValue);
     },
     header: ({ column }) => {

--- a/src/server/router/reviewers.ts
+++ b/src/server/router/reviewers.ts
@@ -17,6 +17,7 @@ const ApplicationForReview = z.object({
     .transform((v) => (v === null ? "" : v)),
   // DH12ApplicationId: z.cuid(),
   DH13ApplicationId: z.cuid(),
+  applicationNumber: z.number(),
   status: z.enum(Status),
   reviewCount: z.number().prefault(0),
   avgScore: z.number().prefault(-1),
@@ -77,6 +78,7 @@ export const reviewerRouter = router({
           DH13Application: {
             select: {
               status: true,
+              applicationNumber: true,
             },
           },
         },
@@ -90,6 +92,7 @@ export const reviewerRouter = router({
                 {
                   ...user,
                   status: DH13Application.status,
+                  applicationNumber: DH13Application.applicationNumber,
                 },
               ],
         ),
@@ -382,6 +385,7 @@ export const reviewerRouter = router({
           DH13Application: {
             select: {
               status: true,
+              applicationNumber: true,
             },
           },
         },
@@ -395,6 +399,7 @@ export const reviewerRouter = router({
                 {
                   ...user,
                   status: DH13Application.status,
+                  applicationNumber: DH13Application.applicationNumber,
                 },
               ],
         ),


### PR DESCRIPTION
Closes #438, depends on #441 merging first, then rebasing **this** branch. 

The grading portal's # column was using the row's array index (client-side, per-page/sort order) instead of a stable application identifier, so the number shown didn't correspond to anything real and shifted when the table was sorted or filtered.

## Changes
- Swap the column's accessorKey/accessorFn from index to applicationNumber, and expose applicationNumber through reviewerRouter (select it from DH13Application and include it in the returned review objects).
- **Visual Change**: widened the filter bar to fit a longer `ApplicationNumber` filter option
<img width="955" height="650" alt="Screenshot 2026-07-20 at 7 13 03 PM" src="https://github.com/user-attachments/assets/0fb05efe-b6ef-4dab-9b14-d4c7aee7f12c" />

- Application numbers now persist through sorts, filters and row deletions:

<img width="955" height="650" alt="Screenshot 2026-07-20 at 7 13 40 PM" src="https://github.com/user-attachments/assets/678f9d39-7a71-4fd5-a126-5cb5f6f4b070" />
