### PR TITLE
chore: update portal schedule

### DIFF
--- a/src/components/Scheduler.tsx
+++ b/src/components/Scheduler.tsx
@@ -382,9 +382,9 @@ const CalendarView: React.FC<{
 
 const GOOGLE_CALENDAR_URL = "https://www.googleapis.com/calendar/v3/calendars/";
 const CALENDAR_ID =
-  "c_4d8a2a89a6a70c398354eba93e7dd292e6cf96d3e628be3f65c38624a5244254@group.calendar.google.com";
+  "c_b09e3e4a8468453986b3eb0e72a61dc9fd96926553065b047f55d5e4ba7adaae@group.calendar.google.com";
 const PUBLIC_KEY = "AIzaSyBnNAISIUKe6xdhq1_rjor2rxoI3UlMY7k";
-const DEFAULT_START_DATE = new Date(2026, 0, 9);
+const DEFAULT_START_DATE = new Date(2027, 0, 9);
 
 const fetchCalendarEvents = async (
   signal?: AbortSignal,

--- a/src/pages/schedule.tsx
+++ b/src/pages/schedule.tsx
@@ -8,7 +8,7 @@ import Drawer from "../components/Drawer";
 import Scheduler from "../components/Scheduler";
 
 const Schedule: NextPage = () => {
-  const startDate = new Date(2026, 0, 10);
+  const startDate = new Date(2027, 0, 9); // January 9, 2027
   return (
     <Drawer
       pageTabs={[


### PR DESCRIPTION
-Replaced the existing Calendar ID in Scheduler.tsx with the ID of the new Google Calendar.
-Updated the schedule start date and number of days displayed in schedule.tsx
-Confirmed new calender is public and events show on /schedule

<img width="1896" height="881" alt="image" src="https://github.com/user-attachments/assets/498a7e42-8691-4d14-92d1-74d8b7b89517" />
